### PR TITLE
Fix bug with priorities not getting saved

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -426,10 +426,11 @@ export class Dotenv {
 	 * @returns paths found
 	 */
 	private dotenvMatcher(dotenv: string | null | undefined, cwd: string): DotenvMatcherResult {
-		const priority = -1;
+		let priority = -1;
 		Object.keys(this.priorities).forEach((fileName) => {
 			if (this.priorities[fileName] > priority && fs.existsSync(path.join(cwd, fileName))) {
 				dotenv = path.join(cwd, fileName);
+				priority = this.priorities[fileName];
 			}
 		});
 		const foundPath = dotenv != null ? cwd : null;


### PR DESCRIPTION
I was working with a repo that has both a `.env` and a `.env.development.local` today and couldn't figure out why calling `.load()` or `.config()` was giving me values from `.env` every time until I deleted the file. Turns out the code that walks the priorities wasn't working – the current priority object was never set, so the file order is all that was determining what was getting picked. This edit fixed it for me locally.