### PR TITLE
fix(deps): fix package exports, default must be last

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
 	"author": "Marco Cesarato <cesarato.developer@gmail.com>",
 	"exports": {
 		".": {
-			"default": "./dist/index.js",
 			"require": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
 		},
 		"./load": "./dist/load.js",
 		"./package.json": "./package.json"


### PR DESCRIPTION
When using `dotenv-mono` under webpack (target: node), it throws an error when the package is loaded because "default" isn't the last entry in package.json.

According to the [documentation in node](https://nodejs.org/api/packages.html#conditional-exports), the order of this actually matters, so this PR is to avoid the error from webpack. This is also detailed in [webpack documentation](https://webpack.js.org/guides/package-exports/#notes-about-ordering).
