### PR TITLE
Stop `find` as soon as match is discovered

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -17,6 +17,8 @@ describe("Dotenv Mono", () => {
 		malformedWithEol: "TEST_MALFORMED_ENV\r\n",
 		defaults: "TEST_DEFAULT_ENV=1",
 		webTest: "TEST_WEB_ENV=1",
+		parent: "PARENT_ENV=1",
+		child: "CHILD_ENV=1",
 	};
 
 	beforeEach(() => {
@@ -33,6 +35,12 @@ describe("Dotenv Mono", () => {
 					"web": {
 						".env.test": mockEnv.webTest,
 					},
+				},
+			},
+			"/parent": {
+				".env": mockEnv.parent,
+				"child": {
+					".env": mockEnv.child,
 				},
 			},
 		});
@@ -120,6 +128,14 @@ describe("Dotenv Mono", () => {
 		expect(() => instance.load()).not.toThrow();
 		const expected = {"TEST_OVERWRITE_ENV": "1", "TEST_DEFAULT_ENV": "1"};
 		expect(instance.plain).toEqual(mockEnv.overwrite);
+		expect(instance.env).toEqual(expected);
+		expect(process.env).toEqual(expect.objectContaining(expected));
+	});
+
+	it("should prefer the nearer of two .env files with the same priority", () => {
+		jest.spyOn(process, "cwd").mockReturnValue("/parent/child");
+		expect(() => instance.load()).not.toThrow();
+		const expected = {"CHILD_ENV": "1"};
 		expect(instance.env).toEqual(expected);
 		expect(process.env).toEqual(expect.objectContaining(expected));
 	});

--- a/src/index.ts
+++ b/src/index.ts
@@ -405,14 +405,13 @@ export class Dotenv {
 		let directory = path.resolve(this.cwd);
 		const {root} = path.parse(directory);
 		let depth = 0;
-		let match = false;
 		while (depth < this.depth) {
 			depth++;
 			const {foundPath, foundDotenv} = matcher(dotenv, directory);
 			dotenv = foundDotenv;
-			if (match) break;
-			if (foundPath) match = true;
-			if (directory === root) break;
+			if (foundPath || directory === root) {
+				break;
+			}
 			directory = path.dirname(directory);
 		}
 		return dotenv;

--- a/src/index.ts
+++ b/src/index.ts
@@ -365,7 +365,7 @@ export class Dotenv {
 				})
 			: {
 					parsed: this.parse(plain),
-					ignoreProcessEnv: true,
+					processEnv: {},
 				};
 
 		if (this.expand) dotenvExpand.expand(config);


### PR DESCRIPTION
## Changes

- Modifies `find` to stop as soon as a match is discovered, and not on the next loop iteration. I _think_ this preserves the current behavior, but I might be missing some subtlety here. At least all of the existing tests pass.
- Replaces `ignoreProcessEnv: true` with `processEnv: {}` in `loadDotenv`. Looks like this was [removed](https://github.com/motdotla/dotenv-expand/blob/master/CHANGELOG.md#removed) from `dotenv-expand`.